### PR TITLE
Fix 退会済ユーザーが再ログイン時に新規登録に遷移しないエラーを解消

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'bootsnap', '>= 1.4.4', require: false
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'pry-rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     chronic (0.10.2)
+    coderay (1.1.3)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
@@ -151,6 +152,11 @@ GEM
     nokogiri (1.14.3-x86_64-linux)
       racc (~> 1.4)
     orm_adapter (0.5.0)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (5.0.1)
     puma (5.6.5)
       nio4r (~> 2.0)
@@ -277,6 +283,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   kaminari
   listen (~> 3.3)
+  pry-rails
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1.7, >= 6.1.7.3)

--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -14,9 +14,14 @@ class Public::SessionsController < Devise::SessionsController
   # end
 
   # POST /resource/sign_in
-  # def create
-  #   super
-  # end
+  def create
+    @end_user = EndUser.find_by(email: params[:end_user][:email])
+    if @end_user.is_deleted == false
+      super
+    else
+      redirect_to new_end_user_registration_path
+    end
+  end
 
   # DELETE /resource/sign_out
   # def destroy
@@ -45,26 +50,5 @@ class Public::SessionsController < Devise::SessionsController
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up)
   end
-
-  # def end_user_state
-  #     ## 【処理内容1】 入力されたemailからアカウントを1件取得
-  #   @end_user = EndUser.find_by(email: params[:end_user][:email])
-  #     ## アカウントを取得できなかった場合、このメソッドを終了する
-  #   return if !@end_user
-  #     ## 【処理内容2】 取得したアカウントのパスワードと入力されたパスワードが一致してるかを判別
-  #   if @end_user.valid_password?(params[:end_user][:password]) && @end_u.is_deleted == true
-  #     ## 【処理内容3】処理内容2がtrueかつcustomerのis_deletedがtrueならサインアップ画面に遷移
-  #     flash[:notice] = "退会済みです。再度ご登録をしてご利用ください。"
-  #     redirect_to new_end_user_registration_path
-  #   else
-  #     flash[:notice] = "ログインに成功しました。"
-  #   end
-  # end
-    def reject_user
-    @end_user = EndUser.find_by(email: params[:end_user][:email])
-      if @end_user.valid_password?(params[:end_user][:password]) && (@end_user.is_deleted == false)
-        redirect_to new_end_user_registration_path, notice = "退会済みです。再度ご登録をしてご利用ください。"
-      end
-    end
 
 end

--- a/app/models/end_user.rb
+++ b/app/models/end_user.rb
@@ -6,10 +6,6 @@ class EndUser < ApplicationRecord
 
   #バリデーション
   validates :nickname, length: { minimum: 2, maximum: 10 }, presence: true
-  # is_deletedがfalseならtrueを返すようバリデーション
-  def active_for_authentication?
-    super && (is_deleted == false)
-  end
 
   # 投稿機能アソシエーション
   has_many :posts, dependent: :destroy


### PR DESCRIPTION
退会済ユーザーが再ログイン時に新規登録に遷移しないエラーを解消